### PR TITLE
Adding volume for persistent logging of perkin logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
      restart: always
      build: ./perkin
      volumes:
-       - ./perkin/logs:/logs
+       - ./perkin/logs:/usr/src/logs
      links:
        - rabbit:rabbit
      ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
   perkin:
      restart: always
      build: ./perkin
+     volumes:
+       - ./perkin/logs:/logs
      links:
        - rabbit:rabbit
      ports:


### PR DESCRIPTION
This change will add a volume to the perkin container when it is rebuilt by docker compose. The volume is to be used as the persistent store for the log4j logging from perkin.

**To Test**
Create a 'logs' folder under your perkin installation folder. Change the log4j.xml file in the src/main/resources location in your code so it looks like this:
`<param name="file" value="logs/perkin.log" />`
- Rebuild perkin using "mvn clean install". 
- Make docker-compose also rebuild perkin using "docker-compose build --no-cache perkin". 
- Run 'docker-compse down' to kill off the containers.
- Run 'docker-compose up to recreate containers.
- Test in console and the log file should appear in log location.
- take docker-compose down and then back up and test again in console. You should see previous logging still present in file after test

**Who should test**
Anyone but Andy.
