### PR TITLE
Add bdd tests to compose image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,4 @@
 
 This repository contains a collection of dockerfiles used throughout the Office of National Statistics (ONS) Survey Data Exchange (SDE) project. The root of the repo contains a docker-compose yaml which builds all elements of the SDE project, along with test tools.
 
-In order to build the docker-compose app, you'll need to check out [Perkin](https://github.com/ONSdigital/perkin), [Posie](https://github.com/ONSdigital/posie) and [sde-console](https://github.com/ONSdigital/sde-console) into the same directory as the compose yaml file. After executing docker-compose up, the sde-console app will be exposed on the containers ip address.
-
-NB: There is a [known bug](https://github.com/docker/machine/issues/3222) with docker-compose which affects flask/alpine based docker images. Unforunately this means that the latest docker (1.10) does not sync changes properly from the flask app to the docker containers. If you want to see changes to the flask app following a build, you either need to be using the current docker for mac beta (which doesn't use virtualbox) or completely destroy your docker machine and build again.
+In order to build the docker-compose app, you'll need to check out [Perkin](https://github.com/ONSdigital/perkin), [Posie](https://github.com/ONSdigital/posie), [sde-bdd](https://github.com/ONSdigital/sde-bdd) and [sde-console](https://github.com/ONSdigital/sde-console) into the same directory as the compose yaml file. After executing docker-compose up, the sde-console app will be exposed on the containers ip address.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,20 @@ services:
        - rabbit:rabbit
      ports:
        - "5000:5000"
+  bdd:
+    build: ./sde-bdd
+    ports:
+      - "5050:5000"
+    links:
+      - posie:posie
+      - rabbit:rabbit
+      - pure-ftpd:pure-ftpd
+    volumes:
+      - ./sde-bdd:/app
+      - ./jwt-test-keys:/keys
+    env_file:
+      - rabbit.env
+      - ftp.env
   console:
      build: ./sde-console
      links:


### PR DESCRIPTION
**Changes**

Include bdd test app to the compose setup.

**How to test**
- docker-compose up
- Check that the bdd app is exposed on port 5050
- Check that reports can be generated by clicking 'run report'

**Who can test**
- Anyone but @iwootten
