### PR TITLE
Add sdx-sequence service to docker compose

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "sdx-transform-cs"]
 	path = sdx-transform-cs
 	url = https://github.com/ONSdigital/sdx-transform-cs.git
+[submodule "sdx-sequence"]
+	path = sdx-sequence
+	url = git@github.com:ONSdigital/sdx-sequence.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,17 @@ services:
        - ftp.env
      networks:
        - sdx-env
+  sdx-sequence:
+    build: ./sdx-sequence
+    ports:
+     - "86:5000"
+    volumes:
+      - ./sdx-sequence/logs:/usr/src/logs
+      - ./sdx-sequence:/app
+    environment:
+      - MONGODB_URL=mongodb://mongodb:27017
+    networks:
+      - sdx-env
   bdd:
      build: ./sdx-bdd
      ports:


### PR DESCRIPTION
**Changes**
- Add sdx-sequence service to docker compose

**How to test**
- Run `docker-compose up`
- Send a GET request to `http://<docker_host>:86/sequence`
- Send another GET request to `http://<docker_host>:86/sequence`
- Send a GET request to `http://<docker_host>:86/image-sequence`
- Send a GET request to `http://<docker_host>:86/batch-sequence`

**Who can test**

Anyone but @ajmaddaford
