### PR TITLE
Favour git URIs for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "sdx-decrypt"]
 	path = sdx-decrypt
-	url = https://github.com/ONSdigital/sdx-decrypt.git
+	url = git@github.com:ONSdigital/sdx-decrypt.git
 [submodule "sdx-collect"]
 	path = sdx-collect
-	url = https://github.com/ONSdigital/sdx-collect.git
+	url = git@github.com:ONSdigital/sdx-collect.git
 [submodule "sdx-bdd"]
 	path = sdx-bdd
-	url = https://github.com/ONSdigital/sdx-bdd.git
+	url = git@github.com:ONSdigital/sdx-bdd.git
 [submodule "sdx-console"]
 	path = sdx-console
-	url = https://github.com/ONSdigital/sdx-console.git
+	url = git@github.com:ONSdigital/sdx-console.git
 [submodule "sdx-store"]
 	path = sdx-store
-	url = https://github.com/ONSdigital/sdx-store.git
+	url = git@github.com:ONSdigital/sdx-store.git
 [submodule "sdx-validate"]
 	path = sdx-validate
-	url = https://github.com/ONSdigital/sdx-validate.git
+	url = git@github.com:ONSdigital/sdx-validate.git
 [submodule "sdx-downstream"]
 	path = sdx-downstream
-	url = https://github.com/ONSdigital/sdx-downstream.git
+	url = git@github.com:ONSdigital/sdx-downstream.git
 [submodule "sdx-transform-cs"]
 	path = sdx-transform-cs
-	url = https://github.com/ONSdigital/sdx-transform-cs.git
+	url = git@github.com:ONSdigital/sdx-transform-cs.git
 [submodule "sdx-sequence"]
 	path = sdx-sequence
 	url = git@github.com:ONSdigital/sdx-sequence.git

--- a/update.sh
+++ b/update.sh
@@ -8,4 +8,3 @@ cd sdx-store
 mvn clean package
 cd $home
 eval $(docker-machine env)
-docker-compose up


### PR DESCRIPTION
**Changes**
- Use git:// style uris for submodules - (we should be using 2FA on github and when enabled any modifications we make in the submodule directory which we want to commit can't be)
- Get rid of the docker up command in the update script (It's not that much of an overhead to have to type it)

**How to test**

Checkout. Build.

**Who can test**

Anyone but @iwootten
