### PR TITLE
Adding a Docker image that extends Ubuntu and adds postgres dev tools

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:16.04
+ENV RUNTIME_PACKAGES="python3"
+ENV BUILD_PACKAGES="curl build-essential python3-dev ca-certificates libssl-dev libffi-dev postgresql libpq-dev"
+
+RUN apt-get update && apt-get install -y $RUNTIME_PACKAGES $BUILD_PACKAGES && curl -sS https://bootstrap.pypa.io/get-pip.py | python3
+
+

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,2 @@
+# postgres
+Basic docker image that extends from Ubuntu 16.04 (current LTS) and adds Python 3 and postgres dev tools


### PR DESCRIPTION
Extend the Ubuntu 16.04 image, adding Python 3 and the postgres dev tools.

This image will then be used by the Postgres versions of SDX store and sequence