### PR TITLE
Added a new ftpd dockerfile

### DIFF
--- a/ftpd/Dockerfile
+++ b/ftpd/Dockerfile
@@ -1,0 +1,9 @@
+FROM stilliard/pure-ftpd
+
+ENV PUBLICHOST localhost
+
+RUN useradd -d /home/ftpusers/ons/ ons
+
+CMD /run.sh -c 50 -C 50 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST -p 30000:30099
+
+EXPOSE 21 30000-30099

--- a/ftpd/Dockerfile
+++ b/ftpd/Dockerfile
@@ -2,10 +2,6 @@ FROM stilliard/pure-ftpd
 
 ENV PUBLICHOST localhost
 
-RUN (echo ons; echo ons) | pure-pw useradd ons -d /home/ftpusers/test -u ftpuser
-RUN pure-pw mkdb
-
 CMD /run.sh -c 50 -C 50 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST -p 30000:30099
 
 EXPOSE 21 30000-30099
-

--- a/ftpd/Dockerfile
+++ b/ftpd/Dockerfile
@@ -2,8 +2,10 @@ FROM stilliard/pure-ftpd
 
 ENV PUBLICHOST localhost
 
-RUN useradd -d /home/ftpusers/ons/ ons
+RUN (echo ons; echo ons) | pure-pw useradd ons -d /home/ftpusers/test -u ftpuser
+RUN pure-pw mkdb
 
 CMD /run.sh -c 50 -C 50 -l puredb:/etc/pure-ftpd/pureftpd.pdb -E -j -R -P $PUBLICHOST -p 30000:30099
 
 EXPOSE 21 30000-30099
+


### PR DESCRIPTION
To be able to have access the ftp page on SDX-Console without a max user error occurring, a new dockerfile is needed to increase the amount of users that can access it.